### PR TITLE
Reorganizing execution order

### DIFF
--- a/src/main/java/org/codehaus/mojo/javancss/NcssReportMojo.java
+++ b/src/main/java/org/codehaus/mojo/javancss/NcssReportMojo.java
@@ -173,6 +173,11 @@ public class NcssReportMojo
     			//an aggregated project that can not be generated at this moment -> try later
     			forLater.addFirst(pr);
     		}
+    		if (pr.project.getModules().size() > 0 && pr.canGenerateAggregateReport())
+    		{	
+    			//an aggregated project that can not be generated at this moment -> try now
+    			pr.generateAggregateReport(locale);
+    		}
     	}
     	
     	while (!forLater.isEmpty())

--- a/src/main/java/org/codehaus/mojo/javancss/NcssReportMojo.java
+++ b/src/main/java/org/codehaus/mojo/javancss/NcssReportMojo.java
@@ -22,6 +22,8 @@ package org.codehaus.mojo.javancss;
 import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.LinkedList;
 import java.util.List;
 import java.util.Locale;
 import java.util.ResourceBundle;
@@ -117,31 +119,18 @@ public class NcssReportMojo
     @Parameter( property = "ncss.skip", defaultValue = "false" )
     private boolean skip;
 
+    
     /**
-     * @see org.apache.maven.reporting.MavenReport#executeReport(java.util.Locale)
+     * The relative path to generate / find XMl reports.
      */
-    public void executeReport( Locale locale )
-        throws MavenReportException
-    {
-        if ( !canGenerateReport() )
-        {
-            return;
-        }
-
-        if ( canGenerateSingleReport() )
-        {
-            generateSingleReport( locale );
-        }
-        if ( canGenerateAggregateReport() )
-        {
-            generateAggregateReport( locale );
-        }
-    }
-
-    private void generateAggregateReport( Locale locale )
-        throws MavenReportException
-    {
-        // All this work just to get "target" so that we can scan the filesystem for
+    private String relativeXMLOutputDirectory;
+    
+    /**
+	 * Constructor. It finds out the relative directory to use for XML output
+	 */
+	public NcssReportMojo() {
+		super();        
+		// All this work just to get "target" so that we can scan the filesystem for
         // child javancss xml files...
         String basedir = project.getBasedir().toString();
         String output = xmlOutputDirectory.toString();
@@ -150,10 +139,9 @@ public class NcssReportMojo
             getLog().debug( "basedir: " + basedir );
             getLog().debug( "output: " + output );
         }
-        String relative = null;
         if ( output.startsWith( basedir ) )
         {
-            relative = output.substring( basedir.length() + 1 );
+            relativeXMLOutputDirectory = output.substring( basedir.length() + 1 );
         }
         else
         {
@@ -162,186 +150,248 @@ public class NcssReportMojo
                                 + "determine the relative location of the XML report" );
             return;
         }
-        getLog().debug( "relative: " + relative );
-        List<ModuleReport> reports = new ArrayList<ModuleReport>();
-        for ( MavenProject child : reactorProjects )
-        {
-            File xmlReport = new File( child.getBasedir() + File.separator + relative, tempFileName );
-            if ( xmlReport.exists() )
-            {
-                reports.add( new ModuleReport( child, loadDocument( xmlReport ) ) );
-            }
-            else
-            {
-                getLog().debug( "xml file not found: " + xmlReport );
-            }
-        }
-        getLog().debug( "Aggregating " + reports.size() + " JavaNCSS reports" );
+        getLog().debug( "relative: " + relativeXMLOutputDirectory );
+        
+	}
 
-        // parse the freshly generated file and write the report
-        NcssAggregateReportGenerator reportGenerator =
-            new NcssAggregateReportGenerator( getSink(), getBundle( locale ), getLog() );
-        reportGenerator.doReport( locale, reports, lineThreshold );
-    }
-
-    private boolean isIncludeExcludeUsed()
-    {
-        return ( ( excludes != null ) || ( includes != null ) );
-    }
-
-    private void generateSingleReport( Locale locale )
+	/**
+     * @see org.apache.maven.reporting.MavenReport#executeReport(java.util.Locale)
+     */
+    public void executeReport( Locale locale )
         throws MavenReportException
     {
-        getLog().info( "Running JavaNCSS " + NcssExecuter.getJavaNCSSVersion() );
-        if ( getLog().isDebugEnabled() )
-        {
-            getLog().debug( "Calling NcssExecuter with src: " + sourceDirectory );
-            getLog().debug( "                       output: " + buildOutputFileName() );
-            getLog().debug( "                     includes: " + includes );
-            getLog().debug( "                     excludes: " + excludes );
-            getLog().debug( "                     encoding: " + getInputEncoding() );
-        }
+    	LinkedList forLater = new LinkedList(); // list to reorder execution of aggregated projects
+    	for (Iterator i = reactorProjects.iterator(); i.hasNext();) 
+    	{
+    		MavenProject mp = (MavenProject) i.next();
+    		ProjectReporter pr = new ProjectReporter(mp);
 
-        // run javaNCss and produce an temp xml file
-        NcssExecuter ncssExecuter;
-        if ( isIncludeExcludeUsed() )
-        {
-            ncssExecuter = new NcssExecuter( scanForSources(), buildOutputFileName() );
-        }
-        else
-        {
-            ncssExecuter = new NcssExecuter( sourceDirectory, buildOutputFileName() );
-        }
-        ncssExecuter.setEncoding( getInputEncoding() ); // in case of null value, JavaNCSS uses platform encoding, as
-        // expected
-
-        ncssExecuter.execute();
-        if ( !isTempReportGenerated() )
-        {
-            throw new MavenReportException( "Can't process temp ncss xml file." );
-        }
-        // parse the freshly generated file and write the report
-        NcssReportGenerator reportGenerator =
-            new NcssReportGenerator( getSink(), getBundle( locale ), getLog(), constructXRefLocation() );
-        reportGenerator.doReport( loadDocument(), lineThreshold );
+    		if (pr.canGenerateSingleReport()) 
+    		{
+    			getLog().debug("running Single Reporting for: " + pr.project.getGroupId() + ":" + pr.project.getArtifactId() +":" + pr.project.getVersion());
+    			pr.generateSingleReport(locale);
+    		}
+    		if (project.getModules().size() > 0 && !pr.canGenerateAggregateReport())
+    		{	
+    			//an aggregated project that can not be generated at this moment -> try later
+    			forLater.addFirst(pr);
+    		}
+    	}
+    	
+    	while (!forLater.isEmpty())
+    	{
+    		ProjectReporter pr = (ProjectReporter) forLater.getFirst();
+    		forLater.removeFirst();
+    		if (pr.canGenerateAggregateReport())
+    		{
+    			getLog().debug("running Aggregate Reporting for: " + pr.project.getGroupId() + ":" + pr.project.getArtifactId() +":" + pr.project.getVersion());
+    			pr.generateAggregateReport(locale);
+    		}
+    		else 
+    		{
+    			// Aggregate report could not be generated, maybe because it depends on other aggregate reports try again later.
+    			forLater.addLast(pr);
+    		}
+    	}
     }
+    private class ProjectReporter {
+    	
 
-    /**
-     * Load the xml file generated by javancss.
-     */
-    private Document loadDocument( File file )
-        throws MavenReportException
-    {
-        try
-        {
-            SAXReader saxReader = new SAXReader();
-            return saxReader.read( ReaderFactory.newXmlReader( file ) );
+        private MavenProject project;
+        
+        private File sourceDirectory;
+       
+        ProjectReporter(MavenProject mp){
+        	project = mp;
+        	sourceDirectory = new File (project.getBuild().getSourceDirectory());
         }
-        catch ( DocumentException de )
+
+        private void generateAggregateReport( Locale locale )
+        		throws MavenReportException
+        		{
+        	// All this work just to get "target" so that we can scan the filesystem for
+        	// child javancss xml files...
+        	
+        	getLog().debug( "relative: " + relativeXMLOutputDirectory );
+        	List<ModuleReport> reports = new ArrayList<ModuleReport>();
+        	for ( MavenProject child : reactorProjects )
+        	{
+        		File xmlReport = new File( child.getBasedir() + File.separator + relativeXMLOutputDirectory, tempFileName );
+        		if ( xmlReport.exists() )
+        		{
+        			reports.add( new ModuleReport( child, loadDocument( xmlReport ) ) );
+        		}
+        		else
+        		{
+        			getLog().debug( "xml file not found: " + xmlReport );
+        		}
+        	}
+        	getLog().debug( "Aggregating " + reports.size() + " JavaNCSS reports" );
+
+        	// parse the freshly generated file and write the report
+        	NcssAggregateReportGenerator reportGenerator =
+        			new NcssAggregateReportGenerator( getSink(), getBundle( locale ), getLog() );
+        	reportGenerator.doReport( locale, reports, lineThreshold );
+        		}
+
+        private boolean isIncludeExcludeUsed()
         {
-            throw new MavenReportException( de.getMessage(), de );
+        	return ( ( excludes != null ) || ( includes != null ) );
         }
-        catch ( IOException ioe )
+
+        private void generateSingleReport( Locale locale )
+        		throws MavenReportException
+        		{
+        	getLog().info( "Running JavaNCSS " + NcssExecuter.getJavaNCSSVersion() );
+        	if ( getLog().isDebugEnabled() )
+        	{
+        		getLog().debug( "Calling NcssExecuter with src: " + sourceDirectory );
+        		getLog().debug( "                       output: " + buildOutputFileName() );
+        		getLog().debug( "                     includes: " + includes );
+        		getLog().debug( "                     excludes: " + excludes );
+        		getLog().debug( "                     encoding: " + getInputEncoding() );
+        	}
+
+        	// run javaNCss and produce an temp xml file
+        	NcssExecuter ncssExecuter;
+        	if ( isIncludeExcludeUsed() )
+        	{
+        		ncssExecuter = new NcssExecuter( scanForSources(), buildOutputFileName() );
+        	}
+        	else
+        	{
+        		ncssExecuter = new NcssExecuter( sourceDirectory, buildOutputFileName() );
+        	}
+        	ncssExecuter.setEncoding( getInputEncoding() ); // in case of null value, JavaNCSS uses platform encoding, as
+        	// expected
+
+        	ncssExecuter.execute();
+        	if ( !isTempReportGenerated() )
+        	{
+        		throw new MavenReportException( "Can't process temp ncss xml file." );
+        	}
+        	// parse the freshly generated file and write the report
+        	NcssReportGenerator reportGenerator =
+        			new NcssReportGenerator( getSink(), getBundle( locale ), getLog(), constructXRefLocation() );
+        	reportGenerator.doReport( loadDocument(), lineThreshold );
+        		}
+
+        /**
+         * Load the xml file generated by javancss.
+         */
+        private Document loadDocument( File file )
+        		throws MavenReportException
+        		{
+        	try
+        	{
+        		SAXReader saxReader = new SAXReader();
+        		return saxReader.read( ReaderFactory.newXmlReader( file ) );
+        	}
+        	catch ( DocumentException de )
+        	{
+        		throw new MavenReportException( de.getMessage(), de );
+        	}
+        	catch ( IOException ioe )
+        	{
+        		throw new MavenReportException( ioe.getMessage(), ioe );
+        	}
+        		}
+
+        private Document loadDocument()
+        		throws MavenReportException
+        		{
+        	return loadDocument( new File( buildOutputFileName() ) );
+        		}
+
+        /**
+         * Check that the expected temporary file generated by JavaNCSS exists.
+         *
+         * @return <code>true</code> if the temporary report exists, <code>false</code> otherwise.
+         */
+        private boolean isTempReportGenerated()
         {
-            throw new MavenReportException( ioe.getMessage(), ioe );
+        	return new File( buildOutputFileName() ).exists();
+        }
+
+        /**
+         * @see org.apache.maven.reporting.MavenReport#canGenerateReport()
+         */
+        public boolean canGenerateReport()
+        {
+        	return !skip && ( canGenerateSingleReport() || canGenerateAggregateReport() );
+        }
+
+        private boolean canGenerateAggregateReport()
+        {
+        	if ( project.getModules().size() == 0 )
+        	{
+        		// no child modules
+        		return false;
+        	}
+        	if ( sourceDirectory != null && sourceDirectory.exists() )
+        	{
+        		// only non-source projects can aggregate
+        		String[] sources = scanForSources();
+        		return !( ( sources != null ) && ( sources.length > 0 ) );
+        	}
+        	return true;
+        }
+
+        private boolean canGenerateSingleReport()
+        {
+        	if ( sourceDirectory == null || !sourceDirectory.exists() )
+        	{
+        		return false;
+        	}
+        	// now that we know we have a valid existing source directory
+        	// we check if any *.java files are existing.
+        	String[] sources = scanForSources();
+        	return ( sources != null ) && ( sources.length > 0 );
+        }
+
+        /**
+         * gets a list of all files in the source directory.
+         *
+         * @return the list of all files in the source directory;
+         */
+        private String[] scanForSources()
+        {
+        	String[] defaultIncludes = { "**\\*.java" };
+        	DirectoryScanner ds = new DirectoryScanner();
+        	if ( includes == null )
+        	{
+        		ds.setIncludes( defaultIncludes );
+        	}
+        	else
+        	{
+        		ds.setIncludes( includes );
+        	}
+        	if ( excludes != null )
+        	{
+        		ds.setExcludes( excludes );
+        	}
+        	ds.setBasedir( sourceDirectory );
+        	getLog().debug( "Scanning base directory " + sourceDirectory );
+        	ds.scan();
+        	int maxFiles = ds.getIncludedFiles().length;
+        	String[] result = new String[maxFiles];
+        	for ( int i = 0; i < maxFiles; i++ )
+        	{
+        		result[i] = sourceDirectory + File.separator + ds.getIncludedFiles()[i];
+        	}
+        	return result;
+        }
+
+        /**
+         * Build a path for the output filename.
+         *
+         * @return A String representation of the output filename.
+         */
+        /* package */String buildOutputFileName()
+        {
+        	return project.getBasedir().getAbsolutePath() + File.separator + relativeXMLOutputDirectory + File.separator + tempFileName;
         }
     }
-
-    private Document loadDocument()
-        throws MavenReportException
-    {
-        return loadDocument( new File( buildOutputFileName() ) );
-    }
-
-    /**
-     * Check that the expected temporary file generated by JavaNCSS exists.
-     *
-     * @return <code>true</code> if the temporary report exists, <code>false</code> otherwise.
-     */
-    private boolean isTempReportGenerated()
-    {
-        return new File( buildOutputFileName() ).exists();
-    }
-
-    /**
-     * @see org.apache.maven.reporting.MavenReport#canGenerateReport()
-     */
-    public boolean canGenerateReport()
-    {
-        return !skip && ( canGenerateSingleReport() || canGenerateAggregateReport() );
-    }
-
-    private boolean canGenerateAggregateReport()
-    {
-        if ( project.getModules().size() == 0 )
-        {
-            // no child modules
-            return false;
-        }
-        if ( sourceDirectory != null && sourceDirectory.exists() )
-        {
-            // only non-source projects can aggregate
-            String[] sources = scanForSources();
-            return !( ( sources != null ) && ( sources.length > 0 ) );
-        }
-        return true;
-    }
-
-    private boolean canGenerateSingleReport()
-    {
-        if ( sourceDirectory == null || !sourceDirectory.exists() )
-        {
-            return false;
-        }
-        // now that we know we have a valid existing source directory
-        // we check if any *.java files are existing.
-        String[] sources = scanForSources();
-        return ( sources != null ) && ( sources.length > 0 );
-    }
-
-    /**
-     * gets a list of all files in the source directory.
-     *
-     * @return the list of all files in the source directory;
-     */
-    private String[] scanForSources()
-    {
-        String[] defaultIncludes = { "**\\*.java" };
-        DirectoryScanner ds = new DirectoryScanner();
-        if ( includes == null )
-        {
-            ds.setIncludes( defaultIncludes );
-        }
-        else
-        {
-            ds.setIncludes( includes );
-        }
-        if ( excludes != null )
-        {
-            ds.setExcludes( excludes );
-        }
-        ds.setBasedir( sourceDirectory );
-        getLog().debug( "Scanning base directory " + sourceDirectory );
-        ds.scan();
-        int maxFiles = ds.getIncludedFiles().length;
-        String[] result = new String[maxFiles];
-        for ( int i = 0; i < maxFiles; i++ )
-        {
-            result[i] = sourceDirectory + File.separator + ds.getIncludedFiles()[i];
-        }
-        return result;
-    }
-
-    /**
-     * Build a path for the output filename.
-     *
-     * @return A String representation of the output filename.
-     */
-    /* package */String buildOutputFileName()
-    {
-        return getXmlOutputDirectory() + File.separator + tempFileName;
-    }
-
     /**
      * @see org.apache.maven.reporting.MavenReport#getName(java.util.Locale)
      */
@@ -356,11 +406,6 @@ public class NcssReportMojo
     public String getDescription( Locale locale )
     {
         return getBundle( locale ).getString( "report.javancss.description" );
-    }
-
-    protected String getXmlOutputDirectory()
-    {
-        return xmlOutputDirectory.getAbsolutePath();
     }
 
     /**

--- a/src/main/java/org/codehaus/mojo/javancss/NcssReportMojo.java
+++ b/src/main/java/org/codehaus/mojo/javancss/NcssReportMojo.java
@@ -154,8 +154,11 @@ public class NcssReportMojo
         }
         getLog().debug( "relative: " + relativeXMLOutputDirectory );
         
+        List<MavenProject> relatedProjects = getAllProjectModules(project, reactorProjects);
+        relatedProjects.add(project);
+        
         LinkedList forLater = new LinkedList(); // list to reorder execution of aggregated projects
-    	for (Iterator i = reactorProjects.iterator(); i.hasNext();) 
+    	for (Iterator i = relatedProjects.iterator(); i.hasNext();) 
     	{
     		MavenProject mp = (MavenProject) i.next();
     		ProjectReporter pr = new ProjectReporter(mp);

--- a/src/main/java/org/codehaus/mojo/javancss/NcssReportMojo.java
+++ b/src/main/java/org/codehaus/mojo/javancss/NcssReportMojo.java
@@ -124,13 +124,15 @@ public class NcssReportMojo
      * The relative path to generate / find XMl reports.
      */
     private String relativeXMLOutputDirectory;
-    
-    /**
-	 * Constructor. It finds out the relative directory to use for XML output
-	 */
-	public NcssReportMojo() {
-		super();        
-		// All this work just to get "target" so that we can scan the filesystem for
+
+	/**
+     * @see org.apache.maven.reporting.MavenReport#executeReport(java.util.Locale)
+     */
+    public void executeReport( Locale locale )
+        throws MavenReportException
+    {
+    	
+    	// All this work just to get "target" so that we can scan the filesystem for
         // child javancss xml files...
         String basedir = project.getBasedir().toString();
         String output = xmlOutputDirectory.toString();
@@ -151,15 +153,7 @@ public class NcssReportMojo
             return;
         }
         getLog().debug( "relative: " + relativeXMLOutputDirectory );
-        
-	}
-
-	/**
-     * @see org.apache.maven.reporting.MavenReport#executeReport(java.util.Locale)
-     */
-    public void executeReport( Locale locale )
-        throws MavenReportException
-    {
+    	
     	LinkedList forLater = new LinkedList(); // list to reorder execution of aggregated projects
     	for (Iterator i = reactorProjects.iterator(); i.hasNext();) 
     	{

--- a/src/main/java/org/codehaus/mojo/javancss/NcssReportMojo.java
+++ b/src/main/java/org/codehaus/mojo/javancss/NcssReportMojo.java
@@ -259,9 +259,10 @@ public class NcssReportMojo
 		private void generateAggregateReport( Locale locale )
         		throws MavenReportException
         		{
-        	// All this work just to get "target" so that we can scan the filesystem for
-        	// child javancss xml files...
-        	
+			if (!project.equals(NcssReportMojo.this.project)) {
+				//this avoids writing in the wrong sink.
+				return;
+			}
         	getLog().debug( "relative: " + relativeXMLOutputDirectory );
         	List<ModuleReport> reports = new ArrayList<ModuleReport>();
         	for ( MavenProject child : reactorProjects )

--- a/src/main/java/org/codehaus/mojo/javancss/NcssReportMojo.java
+++ b/src/main/java/org/codehaus/mojo/javancss/NcssReportMojo.java
@@ -165,7 +165,7 @@ public class NcssReportMojo
     			getLog().debug("running Single Reporting for: " + pr.project.getGroupId() + ":" + pr.project.getArtifactId() +":" + pr.project.getVersion());
     			pr.generateSingleReport(locale);
     		}
-    		if (project.getModules().size() > 0 && !pr.canGenerateAggregateReport())
+    		if (pr.project.getModules().size() > 0 && !pr.canGenerateAggregateReport())
     		{	
     			//an aggregated project that can not be generated at this moment -> try later
     			forLater.addFirst(pr);
@@ -185,6 +185,7 @@ public class NcssReportMojo
     		{
     			// Aggregate report could not be generated, maybe because it depends on other aggregate reports try again later.
     			forLater.addLast(pr);
+    			getLog().warn("Can't generate Aggregate for " + pr.project.getArtifactId() + " at this moment.");
     		}
     	}
     }

--- a/src/main/java/org/codehaus/mojo/javancss/NcssReportMojo.java
+++ b/src/main/java/org/codehaus/mojo/javancss/NcssReportMojo.java
@@ -383,6 +383,12 @@ public class NcssReportMojo
          */
         /* package */String buildOutputFileName()
         {
+        	File outputDir = new File(project.getBasedir().getAbsolutePath() + File.separator + relativeXMLOutputDirectory);
+        	if (!outputDir.exists())
+        	{
+        		outputDir.mkdirs();
+        	}
+        	
         	return project.getBasedir().getAbsolutePath() + File.separator + relativeXMLOutputDirectory + File.separator + tempFileName;
         }
     }

--- a/src/main/java/org/codehaus/mojo/javancss/NcssReportMojo.java
+++ b/src/main/java/org/codehaus/mojo/javancss/NcssReportMojo.java
@@ -376,12 +376,18 @@ public class NcssReportMojo
         	boolean allXMLexists = true;
         	for ( MavenProject child : reactorProjects )
         	{
-        		File xmlReport = new File( child.getBasedir() + File.separator + relativeXMLOutputDirectory, tempFileName );
-        		allXMLexists &= xmlReport.exists();
-        		if (!allXMLexists)
-        		{
-        			break;
-        		}
+        		if (child.getModules().size() == 0) {
+        			// only check availability for non-aggregated projects that have sources
+					File xmlReport = new File(child.getBasedir()
+							+ File.separator + relativeXMLOutputDirectory,
+							tempFileName);
+					allXMLexists &= xmlReport.exists() || 
+							!(new ProjectReporter(child).hasSources());
+					if (!allXMLexists) {
+						getLog().error(xmlReport + " does not exist.");
+						break;
+					}
+				}
         	}
         	return allXMLexists;
         }
@@ -432,6 +438,14 @@ public class NcssReportMojo
         }
 
         /**
+         * Determine if the project has sources.
+		 * @return
+		 */
+		private boolean hasSources() {
+			return sourceDirectory.exists() && scanForSources().length > 0;
+		}
+
+		/**
          * Build a path for the output filename.
          *
          * @return A String representation of the output filename.

--- a/src/main/java/org/codehaus/mojo/javancss/NcssReportMojo.java
+++ b/src/main/java/org/codehaus/mojo/javancss/NcssReportMojo.java
@@ -248,9 +248,12 @@ public class NcssReportMojo
 		private void buildSubReactor() {
 			getLog().debug("Building sub reactor project list for " + project.getArtifactId());
 			reactorProjects = getAllProjectModules(project, NcssReportMojo.this.reactorProjects);
-			for (MavenProject pr : reactorProjects) {
-				getLog().debug("\tAdding " + pr.getArtifactId() + " to sub reactor.");
-			}
+			if ( getLog().isDebugEnabled() )
+	        {
+				for (MavenProject pr : reactorProjects) {
+					getLog().debug("\tAdding " + pr.getArtifactId() + " to sub reactor.");
+				}
+	        }
 		}
 
 		private void generateAggregateReport( Locale locale )

--- a/src/main/java/org/codehaus/mojo/javancss/NcssReportMojo.java
+++ b/src/main/java/org/codehaus/mojo/javancss/NcssReportMojo.java
@@ -153,7 +153,7 @@ public class NcssReportMojo
             return;
         }
         getLog().debug( "relative: " + relativeXMLOutputDirectory );
-    	
+        
     	LinkedList forLater = new LinkedList(); // list to reorder execution of aggregated projects
     	for (Iterator i = reactorProjects.iterator(); i.hasNext();) 
     	{
@@ -329,7 +329,17 @@ public class NcssReportMojo
         		String[] sources = scanForSources();
         		return !( ( sources != null ) && ( sources.length > 0 ) );
         	}
-        	return true;
+        	boolean allXMLexists = true;
+        	for ( MavenProject child : reactorProjects )
+        	{
+        		File xmlReport = new File( child.getBasedir() + File.separator + relativeXMLOutputDirectory, tempFileName );
+        		allXMLexists &= xmlReport.exists();
+        		if (!allXMLexists)
+        		{
+        			break;
+        		}
+        	}
+        	return allXMLexists;
         }
 
         private boolean canGenerateSingleReport()

--- a/src/main/java/org/codehaus/mojo/javancss/NcssReportMojo.java
+++ b/src/main/java/org/codehaus/mojo/javancss/NcssReportMojo.java
@@ -380,7 +380,7 @@ public class NcssReportMojo
         	for (String string : sources) {
         		latestModificationInSource = Math.max(latestModificationInSource, new File(string).lastModified());
 			}
-        	return latestModificationInSource < new File( buildOutputFileName() ).lastModified();
+        	return latestModificationInSource > new File( buildOutputFileName() ).lastModified();
         }
 
         /**

--- a/src/site/apt/usage.apt.vm
+++ b/src/site/apt/usage.apt.vm
@@ -40,10 +40,11 @@ Usage
 
 *Aggregate Reporting
 
-  When running against a project which has no source but has child modules, the JavaNCSS plugin will attempt to aggregate
-  any child JavaNCSS reports into an aggregate report.  Unfortunately Maven's internal support for report aggregation
-  is rather poor so it does have a number of limitations.  Foremost the aggregate report is generated <<before>> the child
-  reports so you must re-run the JavaNCSS report after the children have generated, like this:
+  Since version 2.2 running against a project that contains only child modules, the plugin will generate all the project's 
+  reports, including any aggregated subprojects recursively.
+  
+  For versions prior to 2.2 the aggregate report is generated <<before>> the child reports so you must re-run the JavaNCSS 
+  report after the children have generated, like this:
 
 -------------------
   mvn clean site (generate the site for every module recursively)


### PR DESCRIPTION
with this change, aggregated reports can be generated regardless if the modules have been generated or not. 
because aggregated projects are executed after single reports thanks to an execution list and the submersion of the generator methods in the ProjectReporter class.
