### PR TITLE
Support for Maven Site 4.0.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
    <parent>
       <groupId>org.codehaus.mojo</groupId>
       <artifactId>mojo-parent</artifactId>
-      <version>36</version>
+      <version>86</version>
    </parent>
 
    <artifactId>javancss-maven-plugin</artifactId>
@@ -68,17 +68,17 @@
       <dependency>
          <groupId>org.codehaus.plexus</groupId>
          <artifactId>plexus-utils</artifactId>
-         <version>3.0.24</version>
+         <version>4.0.2</version>
       </dependency>
       <dependency>
          <groupId>org.apache.maven</groupId>
          <artifactId>maven-project</artifactId>
-         <version>2.0</version>
+         <version>2.2.1</version>
       </dependency>
       <dependency>
          <groupId>org.apache.maven</groupId>
          <artifactId>maven-model</artifactId>
-         <version>2.0</version>
+         <version>3.9.9</version>
       </dependency>
       <dependency>
          <groupId>org.apache.maven</groupId>
@@ -87,17 +87,17 @@
       <dependency>
          <groupId>org.apache.maven.reporting</groupId>
          <artifactId>maven-reporting-api</artifactId>
-         <version>3.0</version>
+         <version>4.0.0</version>
       </dependency>
       <dependency>
          <groupId>org.apache.maven.doxia</groupId>
          <artifactId>doxia-sink-api</artifactId>
-         <version>1.6</version>
+         <version>2.0.0</version>
       </dependency>
       <dependency>
          <groupId>org.apache.maven.doxia</groupId>
          <artifactId>doxia-core</artifactId>
-         <version>1.6</version>
+         <version>2.0.0</version>
       </dependency>
       <dependency>
          <groupId>dom4j</groupId>
@@ -107,12 +107,12 @@
       <dependency>
          <groupId>jaxen</groupId>
          <artifactId>jaxen</artifactId>
-         <version>1.1.6</version>
+         <version>2.0.0</version>
       </dependency>
       <dependency>
          <groupId>org.apache.maven.reporting</groupId>
          <artifactId>maven-reporting-impl</artifactId>
-         <version>2.4</version>
+         <version>4.0.0</version>
       </dependency>
       <dependency>
          <groupId>org.codehaus.javancss</groupId>
@@ -125,9 +125,9 @@
          <scope>test</scope>
       </dependency>
       <dependency>
-         <groupId>easymock</groupId>
+         <groupId>org.easymock</groupId>
          <artifactId>easymock</artifactId>
-         <version>1.1</version>
+         <version>5.5.0</version>
          <scope>test</scope>
       </dependency>
    </dependencies>
@@ -135,6 +135,7 @@
    <properties>
       <javancss-version>33.54</javancss-version>
       <sitePluginVersion>3.4</sitePluginVersion>
+      <spotless.check.skip>true</spotless.check.skip>
    </properties>
 
   <build>

--- a/pom.xml
+++ b/pom.xml
@@ -78,7 +78,7 @@
       <dependency>
          <groupId>org.apache.maven</groupId>
          <artifactId>maven-project</artifactId>
-         <version>2.2.1</version>
+         <version>3.0-alpha-2</version>
       </dependency>
       <dependency>
          <groupId>org.apache.maven</groupId>
@@ -140,7 +140,6 @@
    <properties>
       <javancss-version>33.54</javancss-version>
       <sitePluginVersion>3.4</sitePluginVersion>
-      <spotless.check.skip>true</spotless.check.skip>
    </properties>
 
   <build>

--- a/pom.xml
+++ b/pom.xml
@@ -67,6 +67,11 @@
      </dependency>
       <dependency>
          <groupId>org.codehaus.plexus</groupId>
+         <artifactId>plexus-xml</artifactId>
+         <version>4.0.4</version>
+      </dependency>
+      <dependency>
+         <groupId>org.codehaus.plexus</groupId>
          <artifactId>plexus-utils</artifactId>
          <version>4.0.2</version>
       </dependency>

--- a/src/main/java/org/codehaus/mojo/javancss/NcssExecuter.java
+++ b/src/main/java/org/codehaus/mojo/javancss/NcssExecuter.java
@@ -127,9 +127,9 @@ public class NcssExecuter
 
     private String limit( String source, int lines )
     {
-        BufferedReader reader = new BufferedReader( new StringReader( source ) );
         StringBuilder sb = new StringBuilder();
-        try
+        
+        try(BufferedReader reader = new BufferedReader(new StringReader(source)))
         {
             for ( int i = 0; i < lines; i++ )
             {
@@ -144,7 +144,6 @@ public class NcssExecuter
                     sb.append( line );
                 }
             }
-              reader.close();
         }
         catch ( IOException ioe )
         {

--- a/src/main/java/org/codehaus/mojo/javancss/NcssExecuter.java
+++ b/src/main/java/org/codehaus/mojo/javancss/NcssExecuter.java
@@ -25,12 +25,9 @@ import java.io.IOException;
 import java.io.StringReader;
 import java.util.ArrayList;
 import java.util.List;
-
 import javancss.Javancss;
 import javancss.parser.ParseException;
-
 import org.apache.maven.reporting.MavenReportException;
-import org.codehaus.plexus.util.IOUtil;
 
 /**
  * The NcssExecuter is able to call JavaNCSS to produce a code analysis.<br>
@@ -147,15 +144,13 @@ public class NcssExecuter
                     sb.append( line );
                 }
             }
+              reader.close();
         }
         catch ( IOException ioe )
         {
             // cannot happen: in-memory StringReader
         }
-        finally
-        {
-            IOUtil.close( reader );
-        }
+        
         return sb.toString();
     }
 

--- a/src/main/java/org/codehaus/mojo/javancss/NcssReportGenerator.java
+++ b/src/main/java/org/codehaus/mojo/javancss/NcssReportGenerator.java
@@ -23,9 +23,8 @@ import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 import java.util.ResourceBundle;
-
-import org.apache.maven.plugin.logging.Log;
 import org.apache.maven.doxia.sink.Sink;
+import org.apache.maven.plugin.logging.Log;
 import org.dom4j.Document;
 import org.dom4j.Node;
 
@@ -100,60 +99,96 @@ public class NcssReportGenerator
 
     private void doMainPackageAnalysis( Document document )
     {
+        String[] headers = {
+            "report.javancss.header.package",
+            "report.javancss.header.classe",
+            "report.javancss.header.function",
+            "report.javancss.header.ncss",
+            "report.javancss.header.javadoc",
+            "report.javancss.header.javadoc_line",
+            "report.javancss.header.single_comment",
+            "report.javancss.header.multi_comment"
+        };
+        
+        String[] fields = {
+                "classes",
+                "functions",
+                "ncss",
+                "javadocs",
+                "javadoc_lines",
+                "single_comment_lines",
+                "multi_comment_lines"
+            };        
+        
+        List<Node> list = document.selectNodes( "//javancss/packages/package" );
+        
         subtitleHelper( getString( "report.javancss.package.text" ) );
         getSink().table();
-        getSink().tableRow();
+        getSink().tableRows(null, true);
+        
         // HEADER
-        headerCellHelper( getString( "report.javancss.header.package" ) );
-        headerCellHelper( getString( "report.javancss.header.classe" ) );
-        headerCellHelper( getString( "report.javancss.header.function" ) );
-        headerCellHelper( getString( "report.javancss.header.ncss" ) );
-        headerCellHelper( getString( "report.javancss.header.javadoc" ) );
-        headerCellHelper( getString( "report.javancss.header.javadoc_line" ) );
-        headerCellHelper( getString( "report.javancss.header.single_comment" ) );
-        headerCellHelper( getString( "report.javancss.header.multi_comment" ) );
+        getSink().tableRow();
+        for (String header : headers) 
+        {
+            headerCellHelper(getString(header));
+        }
         getSink().tableRow_();
+        
         // DATA
-        List<Node> list = document.selectNodes( "//javancss/packages/package" );
         Collections.<Node>sort( list, new NumericNodeComparator( "ncss" ) );
         for ( Node node : list )
         {
             getSink().tableRow();
-            tableCellHelper( node.valueOf( "name" ) );
-            tableCellHelper( node.valueOf( "classes" ) );
-            tableCellHelper( node.valueOf( "functions" ) );
-            tableCellHelper( node.valueOf( "ncss" ) );
-            tableCellHelper( node.valueOf( "javadocs" ) );
-            tableCellHelper( node.valueOf( "javadoc_lines" ) );
-            tableCellHelper( node.valueOf( "single_comment_lines" ) );
-            tableCellHelper( node.valueOf( "multi_comment_lines" ) );
+            getSink().tableCell();
+            getSink().text(node.valueOf("name"));
+            getSink().tableCell_();
+            
+            for (String field : fields) 
+            {
+                tableCellHelper(node.valueOf(field));
+            }
+
             getSink().tableRow_();
         }
+        getSink().tableRows_();
         getSink().table_();
     }
 
     private void doTotalPackageAnalysis( Document document )
     {
-        getSink().table();
-        getSink().tableRow();
-        headerCellHelper( getString( "report.javancss.header.classetotal" ) );
-        headerCellHelper( getString( "report.javancss.header.functiontotal" ) );
-        headerCellHelper( getString( "report.javancss.header.ncsstotal" ) );
-        headerCellHelper( getString( "report.javancss.header.javadoc" ) );
-        headerCellHelper( getString( "report.javancss.header.javadoc_line" ) );
-        headerCellHelper( getString( "report.javancss.header.single_comment" ) );
-        headerCellHelper( getString( "report.javancss.header.multi_comment" ) );
-        getSink().tableRow_();
+        String[] headers = {
+            "report.javancss.header.classetotal",
+            "report.javancss.header.functiontotal",
+            "report.javancss.header.ncsstotal",
+            "report.javancss.header.javadoc",
+            "report.javancss.header.javadoc_line",
+            "report.javancss.header.single_comment",
+            "report.javancss.header.multi_comment"
+        };
+        
+        String[] fields = {
+            "classes", "functions", "ncss", "javadocs", "javadoc_lines", "single_comment_lines", "multi_comment_lines"
+        };
+        
         Node node = document.selectSingleNode( "//javancss/packages/total" );
+
+        getSink().table();
+        getSink().tableRows(null, true);
+        
         getSink().tableRow();
-        tableCellHelper( node.valueOf( "classes" ) );
-        tableCellHelper( node.valueOf( "functions" ) );
-        tableCellHelper( node.valueOf( "ncss" ) );
-        tableCellHelper( node.valueOf( "javadocs" ) );
-        tableCellHelper( node.valueOf( "javadoc_lines" ) );
-        tableCellHelper( node.valueOf( "single_comment_lines" ) );
-        tableCellHelper( node.valueOf( "multi_comment_lines" ) );
+        for (String header : headers) 
+        {
+            headerCellHelper(getString(header));
+        }
         getSink().tableRow_();
+        
+        getSink().tableRow();      
+        for (String field : fields) 
+        {
+            tableCellHelper(node.valueOf(field));
+        }       
+        getSink().tableRow_();
+        getSink().tableRows_();
         getSink().table_();
     }
 
@@ -178,16 +213,27 @@ public class NcssReportGenerator
     // generic method called by doTopObjectFunctions & doTopObjectNCss
     private void doTopObjectGeneric( List<Node> nodeList )
     {
-        getSink().table();
-        getSink().tableRow();
-        headerCellHelper( getString( "report.javancss.header.object" ) );
-        headerCellHelper( getString( "report.javancss.header.ncss" ) );
-        headerCellHelper( getString( "report.javancss.header.function" ) );
-        headerCellHelper( getString( "report.javancss.header.classe" ) );
-        headerCellHelper( getString( "report.javancss.header.javadoc" ) );
-        getSink().tableRow_();
-        Iterator<Node> nodeIterator = nodeList.iterator();
         int i = 0;
+        String[] headers = {
+            "report.javancss.header.object",
+            "report.javancss.header.ncss",
+            "report.javancss.header.function",
+            "report.javancss.header.classe",
+            "report.javancss.header.javadoc"
+        };
+        String[] fields = {"ncss", "functions", "classes", "javadocs"};
+        Iterator<Node> nodeIterator = nodeList.iterator();
+        
+        getSink().table();
+        getSink().tableRows(null, true);
+        
+        getSink().tableRow();
+        for (String header : headers) 
+        {
+            headerCellHelper(getString(header));
+        }
+        getSink().tableRow_();
+        
         while ( nodeIterator.hasNext() && ( i++ < lineThreshold ) )
         {
             Node node = nodeIterator.next();
@@ -195,28 +241,39 @@ public class NcssReportGenerator
             getSink().tableCell();
             jxrLink( node.valueOf( "name" ) );
             getSink().tableCell_();
-            tableCellHelper( node.valueOf( "ncss" ) );
-            tableCellHelper( node.valueOf( "functions" ) );
-            tableCellHelper( node.valueOf( "classes" ) );
-            tableCellHelper( node.valueOf( "javadocs" ) );
+            
+            for (String field : fields) 
+            {
+                tableCellHelper(node.valueOf(field));
+            }
             getSink().tableRow_();
-        }
+        }       
+        getSink().tableRows_();
         getSink().table_();
     }
 
     private void doObjectAverage( Document document )
     {
-        subtitleHelper( getString( "report.javancss.averages" ) );
-        getSink().table();
-        getSink().tableRow();
-        headerCellHelper( getString( "report.javancss.header.ncssaverage" ) );
-        headerCellHelper( getString( "report.javancss.header.programncss" ) );
-        headerCellHelper( getString( "report.javancss.header.classeaverage" ) );
-        headerCellHelper( getString( "report.javancss.header.functionaverage" ) );
-        headerCellHelper( getString( "report.javancss.header.javadocaverage" ) );
-        getSink().tableRow_();
+        String[] headers = {
+            "report.javancss.header.ncssaverage",
+            "report.javancss.header.programncss",
+            "report.javancss.header.classeaverage",
+            "report.javancss.header.functionaverage",
+            "report.javancss.header.javadocaverage"
+        };
         Node node = document.selectSingleNode( "//javancss/objects/averages" );
         String totalNcss = document.selectSingleNode( "//javancss/objects/ncss" ).getText();
+        
+        subtitleHelper( getString( "report.javancss.averages" ) );
+        getSink().table();
+        getSink().tableRows(null, true);
+        getSink().tableRow();     
+        for (String header : headers) 
+        {
+            headerCellHelper(getString(header));
+        }      
+        getSink().tableRow_();
+     
         getSink().tableRow();
         tableCellHelper( node.valueOf( "ncss" ) );
         tableCellHelper( totalNcss );
@@ -224,24 +281,37 @@ public class NcssReportGenerator
         tableCellHelper( node.valueOf( "functions" ) );
         tableCellHelper( node.valueOf( "javadocs" ) );
         getSink().tableRow_();
+        getSink().tableRows_();
         getSink().table_();
     }
 
     private void doFunctionAnalysis( Document document )
     {
-        subtitleHelper( getString( "report.javancss.top" ) + " " + lineThreshold + " "
-            + getString( "report.javancss.function.byncss" ) );
-        getSink().table();
-        getSink().tableRow();
-        headerCellHelper( getString( "report.javancss.header.function" ) );
-        headerCellHelper( getString( "report.javancss.header.ncss" ) );
-        headerCellHelper( getString( "report.javancss.header.ccn" ) );
-        headerCellHelper( getString( "report.javancss.header.javadoc" ) );
-        getSink().tableRow_();
+        int i = 0;
+        String[] headers = {
+            "report.javancss.header.function",
+            "report.javancss.header.ncss",
+            "report.javancss.header.ccn",
+            "report.javancss.header.javadoc"
+        };
+        String[] fields = {"ncss", "ccn", "javadocs"};
+        
         List<Node> list = document.selectNodes( "//javancss/functions/function" );
         Collections.<Node>sort( list, new NumericNodeComparator( "ncss" ) );
         Iterator<Node> nodeIterator = list.iterator();
-        int i = 0;
+        
+        subtitleHelper( getString( "report.javancss.top" ) + " " + lineThreshold + " "
+            + getString( "report.javancss.function.byncss" ) );
+        
+        getSink().table();
+        getSink().tableRows(null, true);
+        getSink().tableRow();
+        for (String header : headers) 
+        {
+            headerCellHelper(getString(header));
+        }
+        getSink().tableRow_();
+        
         while ( nodeIterator.hasNext() && ( i++ < lineThreshold ) )
         {
             Node node = nodeIterator.next();
@@ -249,32 +319,46 @@ public class NcssReportGenerator
             getSink().tableCell();
             jxrFunctionLink( node.valueOf( "name" ) );
             getSink().tableCell_();
-            tableCellHelper( node.valueOf( "ncss" ) );
-            tableCellHelper( node.valueOf( "ccn" ) );
-            tableCellHelper( node.valueOf( "javadocs" ) );
+
+            for (String field : fields) 
+            {
+                tableCellHelper(node.valueOf(field));
+            }
             getSink().tableRow_();
         }
+        getSink().tableRows_();
         getSink().table_();
     }
 
     private void doFunctionAverage( Document document )
     {
-        subtitleHelper( getString( "report.javancss.averages" ) );
-        getSink().table();
-        getSink().tableRow();
-        headerCellHelper( getString( "report.javancss.header.programncss" ) );
-        headerCellHelper( getString( "report.javancss.header.ncssaverage" ) );
-        headerCellHelper( getString( "report.javancss.header.ccnaverage" ) );
-        headerCellHelper( getString( "report.javancss.header.javadocaverage" ) );
-        getSink().tableRow_();
         Node node = document.selectSingleNode( "//javancss/functions/function_averages" );
         String totalNcss = document.selectSingleNode( "//javancss/functions/ncss" ).getText();
+        String[] headers = {
+            "report.javancss.header.programncss",
+            "report.javancss.header.ncssaverage",
+            "report.javancss.header.ccnaverage",
+            "report.javancss.header.javadocaverage"
+        };
+        
+        subtitleHelper( getString( "report.javancss.averages" ) );
+        getSink().table();
+        getSink().tableRows(null, true);
+        getSink().tableRow();
+  
+        for (String header : headers) 
+        {
+            tableCellHelper(getString(header));
+        }
+        
+        getSink().tableRow_();
         getSink().tableRow();
         tableCellHelper( totalNcss );
         tableCellHelper( node.valueOf( "ncss" ) );
         tableCellHelper( node.valueOf( "ccn" ) );
         tableCellHelper( node.valueOf( "javadocs" ) );
         getSink().tableRow_();
+        getSink().tableRows_();
         getSink().table_();
     }
 
@@ -285,7 +369,7 @@ public class NcssReportGenerator
         paragraphHelper( getString( "report.javancss.explanation.ncss.paragraph2" ) );
         getSink().table();
 
-        getSink().tableRow();
+        getSink().tableRows(null, true);
         headerCellHelper( "" );
         headerCellHelper( getString( "report.javancss.explanation.ncss.table.examples" ) );
         getSink().tableRow_();
@@ -368,7 +452,8 @@ public class NcssReportGenerator
         tableCellHelper( getString( "report.javancss.explanation.ncss.table.label" ) );
         codeCellHelper( "fine :" );
         getSink().tableRow_();
-
+        
+        getSink().tableRows_();
         getSink().table_();
         paragraphHelper( getString( "report.javancss.explanation.ncss.paragraph3" ) );
 

--- a/src/main/java/org/codehaus/mojo/javancss/NcssReportGenerator.java
+++ b/src/main/java/org/codehaus/mojo/javancss/NcssReportGenerator.java
@@ -108,17 +108,16 @@ public class NcssReportGenerator
             "report.javancss.header.javadoc_line",
             "report.javancss.header.single_comment",
             "report.javancss.header.multi_comment"
-        };
-        
+        };       
         String[] fields = {
-                "classes",
-                "functions",
-                "ncss",
-                "javadocs",
-                "javadoc_lines",
-                "single_comment_lines",
-                "multi_comment_lines"
-            };        
+            "classes",
+            "functions",
+            "ncss",
+            "javadocs",
+            "javadoc_lines",
+            "single_comment_lines",
+            "multi_comment_lines"
+        };        
         
         List<Node> list = document.selectNodes( "//javancss/packages/package" );
         
@@ -128,14 +127,17 @@ public class NcssReportGenerator
         
         // HEADER
         getSink().tableRow();
+        
         for (String header : headers) 
         {
             headerCellHelper(getString(header));
         }
+        
         getSink().tableRow_();
         
         // DATA
         Collections.<Node>sort( list, new NumericNodeComparator( "ncss" ) );
+        
         for ( Node node : list )
         {
             getSink().tableRow();
@@ -164,29 +166,35 @@ public class NcssReportGenerator
             "report.javancss.header.javadoc_line",
             "report.javancss.header.single_comment",
             "report.javancss.header.multi_comment"
-        };
-        
+        };      
         String[] fields = {
-            "classes", "functions", "ncss", "javadocs", "javadoc_lines", "single_comment_lines", "multi_comment_lines"
+            "classes", 
+            "functions", 
+            "ncss", "javadocs", 
+            "javadoc_lines", 
+            "single_comment_lines", 
+            "multi_comment_lines"
         };
         
         Node node = document.selectSingleNode( "//javancss/packages/total" );
 
         getSink().table();
-        getSink().tableRows(null, true);
-        
+        getSink().tableRows(null, true);        
         getSink().tableRow();
+        
         for (String header : headers) 
         {
             headerCellHelper(getString(header));
         }
-        getSink().tableRow_();
         
+        getSink().tableRow_();    
         getSink().tableRow();      
+        
         for (String field : fields) 
         {
             tableCellHelper(node.valueOf(field));
         }       
+        
         getSink().tableRow_();
         getSink().tableRows_();
         getSink().table_();
@@ -214,24 +222,32 @@ public class NcssReportGenerator
     private void doTopObjectGeneric( List<Node> nodeList )
     {
         int i = 0;
+        
         String[] headers = {
             "report.javancss.header.object",
             "report.javancss.header.ncss",
             "report.javancss.header.function",
             "report.javancss.header.classe",
             "report.javancss.header.javadoc"
+        };        
+        String[] fields = {
+            "ncss", 
+            "functions", 
+            "classes", 
+            "javadocs"
         };
-        String[] fields = {"ncss", "functions", "classes", "javadocs"};
+        
         Iterator<Node> nodeIterator = nodeList.iterator();
         
         getSink().table();
-        getSink().tableRows(null, true);
-        
+        getSink().tableRows(null, true);      
         getSink().tableRow();
+        
         for (String header : headers) 
         {
             headerCellHelper(getString(header));
         }
+        
         getSink().tableRow_();
         
         while ( nodeIterator.hasNext() && ( i++ < lineThreshold ) )
@@ -246,8 +262,10 @@ public class NcssReportGenerator
             {
                 tableCellHelper(node.valueOf(field));
             }
+            
             getSink().tableRow_();
         }       
+        
         getSink().tableRows_();
         getSink().table_();
     }
@@ -261,6 +279,7 @@ public class NcssReportGenerator
             "report.javancss.header.functionaverage",
             "report.javancss.header.javadocaverage"
         };
+        
         Node node = document.selectSingleNode( "//javancss/objects/averages" );
         String totalNcss = document.selectSingleNode( "//javancss/objects/ncss" ).getText();
         
@@ -268,10 +287,12 @@ public class NcssReportGenerator
         getSink().table();
         getSink().tableRows(null, true);
         getSink().tableRow();     
+        
         for (String header : headers) 
         {
             headerCellHelper(getString(header));
         }      
+        
         getSink().tableRow_();
      
         getSink().tableRow();
@@ -288,6 +309,7 @@ public class NcssReportGenerator
     private void doFunctionAnalysis( Document document )
     {
         int i = 0;
+        
         String[] headers = {
             "report.javancss.header.function",
             "report.javancss.header.ncss",
@@ -306,10 +328,12 @@ public class NcssReportGenerator
         getSink().table();
         getSink().tableRows(null, true);
         getSink().tableRow();
+        
         for (String header : headers) 
         {
             headerCellHelper(getString(header));
         }
+        
         getSink().tableRow_();
         
         while ( nodeIterator.hasNext() && ( i++ < lineThreshold ) )
@@ -324,8 +348,10 @@ public class NcssReportGenerator
             {
                 tableCellHelper(node.valueOf(field));
             }
+            
             getSink().tableRow_();
         }
+        
         getSink().tableRows_();
         getSink().table_();
     }
@@ -334,6 +360,7 @@ public class NcssReportGenerator
     {
         Node node = document.selectSingleNode( "//javancss/functions/function_averages" );
         String totalNcss = document.selectSingleNode( "//javancss/functions/ncss" ).getText();
+        
         String[] headers = {
             "report.javancss.header.programncss",
             "report.javancss.header.ncssaverage",

--- a/src/main/java/org/codehaus/mojo/javancss/NcssReportMojo.java
+++ b/src/main/java/org/codehaus/mojo/javancss/NcssReportMojo.java
@@ -235,7 +235,8 @@ public class NcssReportMojo
         try
         {
             SAXReader saxReader = new SAXReader();
-            try (Reader reader = new XmlStreamReader(file)) {
+            try (Reader reader = new XmlStreamReader(file)) 
+            {
                 return saxReader.read(reader);
             }
         }

--- a/src/main/java/org/codehaus/mojo/javancss/NcssReportMojo.java
+++ b/src/main/java/org/codehaus/mojo/javancss/NcssReportMojo.java
@@ -21,11 +21,11 @@ package org.codehaus.mojo.javancss;
 
 import java.io.File;
 import java.io.IOException;
+import java.io.Reader;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
 import java.util.ResourceBundle;
-
 import org.apache.maven.model.ReportPlugin;
 import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
@@ -34,8 +34,8 @@ import org.apache.maven.reporting.AbstractMavenReport;
 import org.apache.maven.reporting.MavenReportException;
 import org.codehaus.plexus.util.DirectoryScanner;
 import org.codehaus.plexus.util.PathTool;
-import org.codehaus.plexus.util.ReaderFactory;
 import org.codehaus.plexus.util.StringUtils;
+import org.codehaus.plexus.util.xml.XmlStreamReader;
 import org.dom4j.Document;
 import org.dom4j.DocumentException;
 import org.dom4j.io.SAXReader;
@@ -235,7 +235,9 @@ public class NcssReportMojo
         try
         {
             SAXReader saxReader = new SAXReader();
-            return saxReader.read( ReaderFactory.newXmlReader( file ) );
+            try (Reader reader = new XmlStreamReader(file)) {
+                return saxReader.read(reader);
+            }
         }
         catch ( DocumentException de )
         {

--- a/src/main/java/org/codehaus/mojo/javancss/NcssReportMojo.java
+++ b/src/main/java/org/codehaus/mojo/javancss/NcssReportMojo.java
@@ -150,7 +150,7 @@ public class NcssReportMojo
             getLog().debug( "basedir: " + basedir );
             getLog().debug( "output: " + output );
         }
-        String relative = null;
+        String relative;
         if ( output.startsWith( basedir ) )
         {
             relative = output.substring( basedir.length() + 1 );
@@ -163,7 +163,7 @@ public class NcssReportMojo
             return;
         }
         getLog().debug( "relative: " + relative );
-        List<ModuleReport> reports = new ArrayList<ModuleReport>();
+        List<ModuleReport> reports = new ArrayList<>();
         for ( MavenProject child : reactorProjects )
         {
             File xmlReport = new File( child.getBasedir() + File.separator + relative, tempFileName );
@@ -275,7 +275,7 @@ public class NcssReportMojo
 
     private boolean canGenerateAggregateReport()
     {
-        if ( project.getModules().size() == 0 )
+        if ( project.getModules().isEmpty() )
         {
             // no child modules
             return false;

--- a/src/test/java/org/codehaus/mojo/javancss/NumericNodeComparatorTest.java
+++ b/src/test/java/org/codehaus/mojo/javancss/NumericNodeComparatorTest.java
@@ -19,10 +19,11 @@ package org.codehaus.mojo.javancss;
  * under the License.
  */
 
-import junit.framework.TestCase;
-
 import org.dom4j.Node;
-import org.easymock.MockControl;
+import static org.easymock.EasyMock.*;
+import static org.junit.Assert.*;
+import org.junit.Before;
+import org.junit.Test;
 
 /**
  * Test for NumericNodeComparator class.
@@ -30,15 +31,12 @@ import org.easymock.MockControl;
  * @author <a href="jeanlaurent@gmail.com">Jean-Laurent de Morlhon</a>
  */
 public class NumericNodeComparatorTest
-    extends TestCase
 {
     private static final String NODE_PROPERTY = "foobar";
 
-    private static final Integer SMALL_VALUE = new Integer( 10 );
+    private static final Integer SMALL_VALUE = 10;
 
-    private static final Integer BIG_VALUE = new Integer( 42 );
-
-    private MockControl control;
+    private static final Integer BIG_VALUE = 42;
 
     private Node bigNodeMock;
 
@@ -46,82 +44,70 @@ public class NumericNodeComparatorTest
 
     private NumericNodeComparator nnc;
 
+    @Before
     public void setUp()
     {
-        control = MockControl.createControl( Node.class );
-        nnc = new NumericNodeComparator( NODE_PROPERTY );
-        bigNodeMock = (Node) control.getMock();
-        smallNodeMock = (Node) control.getMock();
+        nnc = new NumericNodeComparator(NODE_PROPERTY);
+        bigNodeMock = createMock(Node.class);
+        smallNodeMock = createMock(Node.class);
     }
-
+    
+    @Test
     public void testComparePositive()
     {
-        bigNodeMock.numberValueOf( NODE_PROPERTY );
-        control.setReturnValue( BIG_VALUE );
-        smallNodeMock.numberValueOf( NODE_PROPERTY );
-        control.setReturnValue( SMALL_VALUE );
-        control.replay();
-        assertTrue( nnc.compare( smallNodeMock, bigNodeMock ) > 0 );
-        control.verify();
-    }
+        expect(bigNodeMock.numberValueOf(NODE_PROPERTY)).andReturn(BIG_VALUE);
+        expect(smallNodeMock.numberValueOf(NODE_PROPERTY)).andReturn(SMALL_VALUE);
 
+        replay(bigNodeMock, smallNodeMock);
+
+        assertTrue(nnc.compare(smallNodeMock, bigNodeMock) > 0);
+
+        verify(bigNodeMock, smallNodeMock);
+    }
+    
+    @Test
     public void testCompareNegative()
     {
-        bigNodeMock.numberValueOf( NODE_PROPERTY );
-        control.setReturnValue( SMALL_VALUE );
-        smallNodeMock.numberValueOf( NODE_PROPERTY );
-        control.setReturnValue( BIG_VALUE );
-        control.replay();
-        assertTrue( nnc.compare( smallNodeMock, bigNodeMock ) < 0 );
-        control.verify();
-    }
+        expect(bigNodeMock.numberValueOf(NODE_PROPERTY)).andReturn(SMALL_VALUE);
+        expect(smallNodeMock.numberValueOf(NODE_PROPERTY)).andReturn(BIG_VALUE);
 
+        replay(bigNodeMock, smallNodeMock);
+
+        assertTrue(nnc.compare(smallNodeMock, bigNodeMock) < 0);
+
+        verify(bigNodeMock, smallNodeMock);
+    }
+    
+    @Test
     public void testCompareEqual()
     {
-        bigNodeMock.numberValueOf( NODE_PROPERTY );
-        control.setReturnValue( SMALL_VALUE );
-        smallNodeMock.numberValueOf( NODE_PROPERTY );
-        control.setReturnValue( SMALL_VALUE );
-        control.replay();
-        assertEquals( 0, nnc.compare( smallNodeMock, bigNodeMock ) );
-        control.verify();
+        expect(bigNodeMock.numberValueOf(NODE_PROPERTY)).andReturn(SMALL_VALUE);
+        expect(smallNodeMock.numberValueOf(NODE_PROPERTY)).andReturn(SMALL_VALUE);
+
+        replay(bigNodeMock, smallNodeMock);
+
+        assertEquals(0, nnc.compare(smallNodeMock, bigNodeMock));
+
+        verify(bigNodeMock, smallNodeMock);
     }
 
     // should throw npe whenever one of the node is null
+    @Test(expected = NullPointerException.class)
     public void testCompareWithBigNull()
     {
-        smallNodeMock.numberValueOf( NODE_PROPERTY );
-        control.setReturnValue( SMALL_VALUE );
-        control.replay();
-        boolean caught = false;
-        try
-        {
-            nnc.compare( null, smallNodeMock );
-        }
-        catch ( NullPointerException npe )
-        {
-            caught = true;
-        }
-        assertTrue( caught );
-        control.verify();
-    }
+        expect(smallNodeMock.numberValueOf(NODE_PROPERTY)).andReturn(SMALL_VALUE);
+        replay(smallNodeMock);
 
+        nnc.compare(null, smallNodeMock);
+    }
+    
+    @Test(expected = NullPointerException.class)
     public void testCompareWithSmallNull()
     {
-        bigNodeMock.numberValueOf( NODE_PROPERTY );
-        control.setReturnValue( BIG_VALUE, MockControl.ZERO_OR_MORE );
-        control.replay();
-        boolean caught = false;
-        try
-        {
-            nnc.compare( bigNodeMock, null );
-        }
-        catch ( NullPointerException npe )
-        {
-            caught = true;
-        }
-        assertTrue( caught );
-        control.verify();
+        expect(bigNodeMock.numberValueOf(NODE_PROPERTY)).andReturn(BIG_VALUE);
+        replay(bigNodeMock);
+
+        nnc.compare(bigNodeMock, null);
     }
 
 }


### PR DESCRIPTION
- Updated NcssReportGenerator table creation
- Changed NcssExecuter's limit function to use try-resource 
- Updated Dependencies

I mainly focused on getting table generation to work with the latest version of Maven Site. No tests were added, although `NumericNodeComparatorTest` was updated to use the latest version of  `easymock`